### PR TITLE
Update to recente reqwest to pick up recent hyper

### DIFF
--- a/acme-client/Cargo.toml
+++ b/acme-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "acme-client"
 description = "Easy to use ACME client library to issue, renew and revoke TLS certificates"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Onur Aslan <onur@onur.im>"]
 license = "MIT"
 keywords = ["letsencrypt", "acme"]
@@ -14,7 +14,7 @@ error-chain = "0.10"
 log = "0.3"
 rustc-serialize = "0.3"
 hyper = "0.10"
-reqwest = "0.5"
+reqwest = "0.6"
 openssl = "0.9.11"
 
 [dev-dependencies]


### PR DESCRIPTION
This is useful for users of letsencrypt-rs that also use hyper for other purposes.