### PR TITLE
same parameter name for USER_KEY

### DIFF
--- a/letsencrypt-rs/src/main.rs
+++ b/letsencrypt-rs/src/main.rs
@@ -198,7 +198,7 @@ fn sign_certificate(matches: &ArgMatches) -> Result<()> {
 fn revoke_certificate(matches: &ArgMatches) -> Result<()> {
     let directory = Directory::lets_encrypt()?;
     let account = directory.account_registration()
-        .pkey_from_file(matches.value_of("USER_KEY_PATH")
+        .pkey_from_file(matches.value_of("USER_KEY")
                             .ok_or("You need to provide user \
                                    or domain private key used \
                                    to sign certificate.")?)?


### PR DESCRIPTION
It was named USER_KEY in the argument list but used as USER_KEY_PATH.
The _PATH suffix probably originates from the same parameter for the
sign subcommand, which doesn't make sense here though as it only handles
the revocation.

A more elaborate fix would be to name everything similarly, but that has
a higher chance of introducing breakage.
