### PR TITLE
Disable usage of get_tls_sni_challenge in tests

### DIFF
--- a/acme-client/src/lib.rs
+++ b/acme-client/src/lib.rs
@@ -1225,7 +1225,7 @@ mod tests {
         assert!(auth.get_challenge("http").is_some());
         assert!(auth.get_http_challenge().is_some());
         assert!(auth.get_dns_challenge().is_some());
-        assert!(auth.get_tls_sni_challenge().is_some());
+        //assert!(auth.get_tls_sni_challenge().is_some());
 
         for challenge in auth.0 {
             assert!(!challenge.ctype.is_empty());


### PR DESCRIPTION
Let's Encrypt disabled TLS-SNI validation is for new accounts.
For this reason account authorization no longer includes tls_sni
challenge. This patch is disabling usage of get_tls_sni_challenge.