### PR TITLE
descriptive error output using display 

### DIFF
--- a/letsencrypt-rs/src/main.rs
+++ b/letsencrypt-rs/src/main.rs
@@ -117,7 +117,7 @@ fn main() {
     };
 
     if let Err(e) = res {
-        writeln!(io::stderr(), "{}", e).expect("Failed to write stderr");
+        eprintln!("{}", e);
         ::std::process::exit(1);
     }
 }

--- a/letsencrypt-rs/src/main.rs
+++ b/letsencrypt-rs/src/main.rs
@@ -117,7 +117,7 @@ fn main() {
     };
 
     if let Err(e) = res {
-        writeln!(io::stderr(), "{}", e.description()).expect("Failed to write stderr");
+        writeln!(io::stderr(), "{}", e).expect("Failed to write stderr");
         ::std::process::exit(1);
     }
 }


### PR DESCRIPTION
[The display version of the error prints information about the error while the description does not](https://github.com/onur/letsencrypt-rs/blob/5351c370019cadf86c588df223cae9a7a5efa2f8/acme-client/src/lib.rs#L1066).
If you receive an error on the command line you usually want to know why it errors.

I also put another commit there that makes use of the [eprintln! macro](https://doc.rust-lang.org/std/macro.eprintln.html) as opposed to using `writeln!` on stderr.
It's your choice whether you want the latter one, but pretty please do use the first commit.
I'm currently having trouble finding out why exactly I'm getting an "Acme server error" ^^