### PR TITLE
cache for cargo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: rust
 rust:
   - stable
   - nightly
+cache: cargo
 script: cargo build --verbose --all && cargo test --verbose --all


### PR DESCRIPTION
This way it doesn't re-sync the whole registry and doesn't recompile unchanged dependencies.
I could remove `target/` if you want.
Not sure whether that would use stale dependencies or something.
It is however part of the [cargo cache on travis](https://docs.travis-ci.com/user/caching/#rust-cargo-cache).