### PR TITLE
compile on older compiler versions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -356,9 +356,9 @@ fn names_from_csr<P: AsRef<Path>>(csr_path: P) -> Result<HashSet<String>> {
                 let extension_data = X509_EXTENSION_get_data(san_extension.as_ptr());
                 let slc = slice::from_raw_parts((*extension_data).data,
                                                 (*extension_data).length as usize);
-                parse_asn1_octet_str(slc).iter().for_each(|n| {
-                    names.insert(n.to_string());
-                });
+                for name in parse_asn1_octet_str(slc) {
+                    names.insert(name.to_string());
+				}
             }
         }
     }


### PR DESCRIPTION
On the current stable version of OpenBSD (6.2) for example the most current
package is rust-1.20.0.

And honestly, this little piece of syntax is not really necessary in that place ^^
