### PR TITLE
add new feature: vendored-openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ openssl = "0.10"
 clap = { version = "2", optional = true }
 env_logger = { version = "0.4", optional = true }
 foreign-types = { version = "0.3.1", optional = true }
-openssl-sys = { version = "0.9.24", optional = true }
+openssl-sys = { version = "0.9.36", optional = true }
+openssl-probe = { version = "0.1.2", optional = true }
 
 [dev-dependencies]
 env_logger = "0.4"
@@ -34,3 +35,4 @@ required-features = ["cli"]
 [features]
 default = ["cli"]
 cli = ["clap", "env_logger", "openssl-sys", "foreign-types"]
+vendored-openssl = ["openssl/vendored", "openssl-probe"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ revoke TLS certificates.
 
    * [CLI](#cli)
       * [Installation](#installation)
+         * [Vendored OpenSSL](#vendored-openssl)
       * [Usage](#usage)
          * [Sign a certificate](#sign-a-certificate)
          * [Using your own keys and CSR](#using-your-own-keys-and-csr)
@@ -36,6 +37,12 @@ By default acme-client crate comes with a handy CLI.
 You can install acme-client with: `cargo install acme-client` or you can
 download pre-built acme-client binary for Linux in the
 [releases](https://github.com/onur/acme-client/releases) page.
+
+
+### Vendored OpenSSL
+
+acme-client has a feature to build and link OpenSSL statically.
+To activate, run cargo with this param: `--features "vendored-openssl"`
 
 
 ## Usage

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,9 @@ extern crate env_logger;
 extern crate foreign_types;
 extern crate openssl_sys;
 
+#[cfg(feature = "vendored-openssl")]
+extern crate openssl_probe;
+
 
 use std::io::{self, Write};
 use std::path::Path;
@@ -17,6 +20,9 @@ use clap::{Arg, App, SubCommand, ArgMatches};
 
 
 fn main() {
+    #[cfg(feature = "vendored-openssl")]
+    openssl_probe::init_ssl_cert_env_vars();
+
     let matches = App::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
         .about(env!("CARGO_PKG_DESCRIPTION"))


### PR DESCRIPTION
Allow acme-client to be built with `--features "vendored-openssl"` ref: https://github.com/rust-lang/cargo/blob/master/Cargo.toml#L103

The feature set openssl to be built statically, and use openssl-probe to set `SSL_CERT_DIR` automatically, so openssl can find where ca certs reside.

fixes: https://github.com/onur/acme-client/issues/32
