### PR TITLE
Update reqwest to 0.9.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 base64 = "0.9"
 hyper = "0.10"
-reqwest = "0.6"
+reqwest = "0.9"
 openssl = "0.10"
 clap = { version = "2", optional = true }
 env_logger = { version = "0.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,6 @@ pub extern crate openssl;
 extern crate log;
 #[macro_use]
 extern crate error_chain;
-#[macro_use]
 extern crate hyper;
 extern crate reqwest;
 extern crate serde;
@@ -291,7 +290,7 @@ use openssl::hash::{hash, MessageDigest};
 use openssl::pkey::PKey;
 use openssl::x509::{X509, X509Req};
 
-use reqwest::{Client, StatusCode};
+use reqwest::{ClientBuilder, StatusCode};
 
 use helper::{gen_key, b64, read_pkey, gen_csr};
 use error::{Result, ErrorKind};
@@ -399,7 +398,7 @@ impl Directory {
     /// # fn main () { try_main().unwrap(); }
     /// ```
     pub fn from_url(url: &str) -> Result<Directory> {
-        let client = Client::new()?;
+        let client = ClientBuilder::new().build()?;
         let mut res = client.get(url).send()?;
         let mut content = String::new();
         res.read_to_string(&mut content)?;
@@ -450,12 +449,14 @@ impl Directory {
     /// it will try to get nonce header from directory url.
     fn get_nonce(&self) -> Result<String> {
         let url = self.url_for("new-nonce").unwrap_or(&self.url);
-        let client = Client::new()?;
+        let client = ClientBuilder::new().build()?;
         let res = client.get(url).send()?;
         res.headers()
-            .get::<hyperx::ReplayNonce>()
+            .get("Replay-Nonce")
             .ok_or("Replay-Nonce header not found".into())
-            .and_then(|nonce| Ok(nonce.as_str().to_string()))
+            .and_then(|nonce| nonce.to_str()
+                    .map(|s| s.to_string())
+                    .map_err(|_| { "Replay-Nonce not parseable".into()} ))
     }
 
     /// Makes a new post request to directory, signs payload with pkey.
@@ -474,11 +475,11 @@ impl Directory {
             .and_then(|obj| obj.insert("resource".to_owned(), resource_json));
 
         let jws = self.jws(pkey, json)?;
-        let client = Client::new()?;
+        let client = ClientBuilder::new().build()?;
         let mut res = client
             .post(self.url_for(resource)
                       .ok_or(format!("URL for resource: {} not found", resource))?)
-            .body(&jws[..])
+            .body(jws)
             .send()?;
 
         let res_json = {
@@ -491,7 +492,7 @@ impl Directory {
             }
         };
 
-        Ok((*res.status(), res_json))
+        Ok((res.status(), res_json))
     }
 
     /// Makes a Flattened JSON Web Signature from payload
@@ -557,7 +558,7 @@ impl Account {
         });
         let (status, resp) = self.directory().request(self.pkey(), "new-authz", map)?;
 
-        if status != StatusCode::Created {
+        if status != StatusCode::CREATED {
             return Err(ErrorKind::AcmeServerError(resp).into());
         }
 
@@ -646,8 +647,8 @@ impl Account {
         };
 
         match status {
-            StatusCode::Ok => info!("Certificate successfully revoked"),
-            StatusCode::Conflict => warn!("Certificate already revoked"),
+            StatusCode::OK => info!("Certificate successfully revoked"),
+            StatusCode::CONFLICT => warn!("Certificate already revoked"),
             _ => return Err(ErrorKind::AcmeServerError(resp).into()),
         }
 
@@ -733,8 +734,8 @@ impl AccountRegistration {
         let (status, resp) = self.directory.request(&pkey, "new-reg", map)?;
 
         match status {
-            StatusCode::Created => debug!("User successfully registered"),
-            StatusCode::Conflict => debug!("User already registered"),
+            StatusCode::CREATED => debug!("User successfully registered"),
+            StatusCode::CONFLICT => debug!("User already registered"),
             _ => return Err(ErrorKind::AcmeServerError(resp).into()),
         };
 
@@ -793,17 +794,17 @@ impl<'a> CertificateSigner<'a> {
         map.insert("resource".to_owned(), "new-cert".to_owned());
         map.insert("csr".to_owned(), b64(&csr.to_der()?));
 
-        let client = Client::new()?;
+        let client = ClientBuilder::new().build()?;
         let jws = self.account.directory().jws(self.account.pkey(), map)?;
         let mut res = client
             .post(self.account
                       .directory()
                       .url_for("new-cert")
                       .ok_or("new-cert url not found")?)
-            .body(&jws[..])
+            .body(jws)
             .send()?;
 
-        if res.status() != &StatusCode::Created {
+        if res.status() != StatusCode::CREATED {
             let res_json = {
                 let mut res_content = String::new();
                 res.read_to_string(&mut res_content)?;
@@ -895,7 +896,7 @@ impl SignedCertificate {
     /// [`LETSENCRYPT_INTERMEDIATE_CERT_URL`](constant.LETSENCRYPT_INTERMEDIATE_CERT_URL.html).
     /// will be used if url is None.
     fn get_intermediate_certificate(&self, url: Option<&str>) -> Result<X509> {
-        let client = Client::new()?;
+        let client = ClientBuilder::new().build()?;
         let mut res = client
             .get(url.unwrap_or(LETSENCRYPT_INTERMEDIATE_CERT_URL))
             .send()?;
@@ -1015,8 +1016,8 @@ impl<'a> Challenge<'a> {
             self.account.directory().jws(self.account.pkey(), map)?
         };
 
-        let client = Client::new()?;
-        let mut resp = client.post(&self.url).body(&payload[..]).send()?;
+        let client = ClientBuilder::new().build()?;
+        let mut resp = client.post(&self.url).body(payload).send()?;
 
         let mut res_json: Value = {
             let mut res_content = String::new();
@@ -1024,7 +1025,7 @@ impl<'a> Challenge<'a> {
             from_str(&res_content)?
         };
 
-        if resp.status() != &StatusCode::Accepted {
+        if resp.status() != StatusCode::ACCEPTED {
             return Err(ErrorKind::AcmeServerError(res_json).into());
         }
 
@@ -1055,14 +1056,6 @@ impl<'a> Challenge<'a> {
             sleep(Duration::from_secs(2));
         }
     }
-}
-
-
-// header! is making a public struct,
-// our custom header is private and only used privately in this module
-mod hyperx {
-    // ReplayNonce header for hyper
-    header! { (ReplayNonce, "Replay-Nonce") => [String] }
 }
 
 


### PR DESCRIPTION
Older reqwest versions depends on an old openssl crate which does not work with openssl 1.1.1. 

I believe I have not introduced any new panics.

Fixes #43 